### PR TITLE
Fixed typo in Japanese post rules

### DIFF
--- a/epitran/data/post/jpn-Hira.txt
+++ b/epitran/data/post/jpn-Hira.txt
@@ -18,7 +18,7 @@ oo -> oː / _
 
 %Some special notations for long vowels
 ei -> eː / _
-ou -> oː / _
+oɯ -> oː / _
 
 % allophones of "[ら-ろ]" & "[りゃ-りょ]"
 ɾ -> ɖ / # _

--- a/epitran/data/post/jpn-Kana.txt
+++ b/epitran/data/post/jpn-Kana.txt
@@ -18,7 +18,7 @@ oo -> oː / _
 
 %Some special notations for long vowels
 ei -> eː / _
-ou -> oː / _
+oɯ -> oː / _
 
 % allophones of "[ラ-ロ]" & "[リャ-リョ]"
 ɾ -> ɖ / # _


### PR DESCRIPTION
Changed `u` to `ɯ` in one rule in both `data/post/jpn-Hira.txt` and `data/post/jpn-Kana.txt`.

* **What kind of change does this PR introduce?** (Language addition, bug fix, feature, docs update, ...)

<!-- Use below for adding new language -->
* **Checklist**
- [] Have you added adequate tests on epitran/test?
- [] Have you updated the language list in README.md?


* **Sources of information for the test samples** (I'm a native speaker, books, online resources, ...)


* **Sources of information for the rules** (I'm a native speaker, books, online resources, ...)


<!-- Use below for everything else -->
* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


